### PR TITLE
Fix misleading frontend project and auth UI

### DIFF
--- a/src/frontend/src/CreateAccount.jsx
+++ b/src/frontend/src/CreateAccount.jsx
@@ -25,18 +25,23 @@ function CreateAccount() {
             return
         }
 
-        const response = await fetch(`${API_BASE}/auth/add_user`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ username: userid, password: password })
-        })
-        const data = await response.json()
-        if (data.status === 'ok') {
-            login(data.access_token, userid)
-            setError('Account created!')
-            navigate('/dashboard')
-        } else {
-            setError(data.message)
+        try {
+            const response = await fetch(`${API_BASE}/auth/add_user`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username: userid, password: password })
+            })
+            const data = await response.json()
+            if (data.status === 'ok') {
+                login(data.access_token, userid)
+                setError('Account created!')
+                navigate('/dashboard')
+            } else {
+                setError(data.message)
+            }
+        } catch (err) {
+            console.error('Failed to create account', err)
+            setError('Unable to create account. Please try again.')
         }
     }
 

--- a/src/frontend/src/CreateAccount.test.jsx
+++ b/src/frontend/src/CreateAccount.test.jsx
@@ -94,4 +94,18 @@ describe('CreateAccount Component', () => {
             expect(screen.getByText(/username already exists/i)).toBeInTheDocument()
         })
     })
+
+    it('shows a friendly message when account creation fails', async () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        global.fetch = vi.fn().mockRejectedValue(new Error('network down'))
+
+        renderWithProviders(<CreateAccount />)
+        await userEvent.type(screen.getByPlaceholderText('User ID'), 'alice')
+        await userEvent.type(screen.getByPlaceholderText('Password'), 'pass123')
+        await userEvent.type(screen.getByPlaceholderText('Confirm Password'), 'pass123')
+        await userEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+        expect(await screen.findByText(/unable to create account\. please try again\./i)).toBeInTheDocument()
+        expect(errorSpy).toHaveBeenCalledWith('Failed to create account', expect.any(Error))
+    })
 })

--- a/src/frontend/src/Login.jsx
+++ b/src/frontend/src/Login.jsx
@@ -19,20 +19,24 @@ function Login() {
             return
         }
 
-        // Call your Flask backend
-        const response = await fetch(`${API_BASE}/auth/login`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ username: userid, password: password })
-        })
-        const data = await response.json()
-        if (data.status === 'ok') {
-            login(data.access_token, userid)
-            setError('Login successful!')      // redirect on success
-            navigate('/dashboard')
-        }
-        else {
-            setError(data.message)      // show backend error message
+        try {
+            const response = await fetch(`${API_BASE}/auth/login`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username: userid, password: password })
+            })
+            const data = await response.json()
+            if (data.status === 'ok') {
+                login(data.access_token, userid)
+                setError('Login successful!')
+                navigate('/dashboard')
+            }
+            else {
+                setError(data.message)
+            }
+        } catch (err) {
+            console.error('Failed to log in', err)
+            setError('Unable to log in. Please try again.')
         }
     }
 

--- a/src/frontend/src/Login.test.jsx
+++ b/src/frontend/src/Login.test.jsx
@@ -91,4 +91,17 @@ describe('Login Component', () => {
         })
         expect(screen.queryByText(/please fill in all fields/i)).not.toBeInTheDocument()
     })
+
+    it('shows a friendly message when the request fails', async () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        global.fetch = vi.fn().mockRejectedValue(new Error('network down'))
+
+        renderWithProviders(<Login />)
+        await userEvent.type(screen.getByPlaceholderText('User ID'), 'bob')
+        await userEvent.type(screen.getByPlaceholderText('Password'), 'pass')
+        await userEvent.click(screen.getByRole('button', { name: /login/i }))
+
+        expect(await screen.findByText(/unable to log in\. please try again\./i)).toBeInTheDocument()
+        expect(errorSpy).toHaveBeenCalledWith('Failed to log in', expect.any(Error))
+    })
 })

--- a/src/frontend/src/NewProject.jsx
+++ b/src/frontend/src/NewProject.jsx
@@ -15,14 +15,13 @@ const logActivity = async (msg, token) => {
 
 function NewProject() {
     const [projectName, setProjectName] = useState('')
-    const [description, setDescription] = useState('')
     const [error, setError] = useState('')
     const [success, setSuccess] = useState('')
     const [projects, setProjects] = useState([])
     const [joinId, setJoinId] = useState('')
     const [joinError, setJoinError] = useState('')
     const navigate = useNavigate()
-    const { token } = useAuth()
+    const { token, username } = useAuth()
 
     const fetchProjects = async () => {
         if (!token) return;
@@ -35,8 +34,8 @@ function NewProject() {
                 const mapped = data.projects.map(p => ({
                     id: p.project_id,
                     name: p.name,
-                    description: `Owner: ${p.owner}`,
-                    joined: p.joined ?? true
+                    owner: p.owner,
+                    isOwner: p.owner === username
                 }))
                 setProjects(mapped)
             }
@@ -45,7 +44,7 @@ function NewProject() {
 
     useEffect(() => {
         fetchProjects()
-    }, [token])
+    }, [token, username])
 
     const handleSubmit = async (e) => {
         e.preventDefault()
@@ -69,7 +68,6 @@ function NewProject() {
                 setSuccess(`Project "${projectName}" created! ID: ${data.project_id}`)
                 fetchProjects()
                 setProjectName('')
-                setDescription('')
             } else {
                 setError(data.message)
             }
@@ -148,12 +146,6 @@ function NewProject() {
                             value={projectName}
                             onChange={(e) => setProjectName(e.target.value)}
                         />
-                        <textarea
-                            placeholder="Description (optional)"
-                            value={description}
-                            onChange={(e) => setDescription(e.target.value)}
-                            rows={3}
-                        />
                         <button type="submit">Create Project</button>
                     </form>
 
@@ -183,22 +175,23 @@ function NewProject() {
 
                 {projects.length > 0 && (
                     <div className="project-list-box">
-                        <h3>Your Projects ({projects.filter(p => p.joined).length} joined)</h3>
+                        <h3>Your Projects ({projects.length} joined)</h3>
                         {projects.map(p => (
                             <div className="project-item" key={p.id}>
                                 <div className="project-item-info">
                                     <strong>{p.name}</strong>
                                     <span className="project-id">ID: {p.id}</span>
-                                    {p.description && <span className="project-desc">{p.description}</span>}
-                                    <span className="project-date">Created: {p.createdAt}</span>
+                                    <span className="project-desc">Owner: {p.owner}</span>
                                 </div>
                                 <div className="project-item-actions">
-                                    {p.joined ? (
-                                        <span className="badge-joined">Joined</span>
+                                    {p.isOwner ? (
+                                        <span className="badge-joined">Owner</span>
                                     ) : (
                                         <button className="btn-small btn-grey" onClick={() => handleLeave(p.id, p.name)}>Leave</button>
                                     )}
-                                    <button className="btn-small btn-red" onClick={() => handleDelete(p.id, p.name)}>Delete</button>
+                                    {p.isOwner && (
+                                        <button className="btn-small btn-red" onClick={() => handleDelete(p.id, p.name)}>Delete</button>
+                                    )}
                                 </div>
                             </div>
                         ))}

--- a/src/frontend/src/NewProject.test.jsx
+++ b/src/frontend/src/NewProject.test.jsx
@@ -60,7 +60,6 @@ describe('NewProject Component', () => {
         expect(await screen.findByText(/your projects/i)).toBeInTheDocument()
 
         await userEvent.type(screen.getByPlaceholderText('Project Name'), 'Beta')
-        await userEvent.type(screen.getByPlaceholderText('Description (optional)'), 'Important description')
         await userEvent.click(screen.getByRole('button', { name: /create project/i }))
         expect(await screen.findByText(/project "Beta" created!/i)).toBeInTheDocument()
 
@@ -84,8 +83,8 @@ describe('NewProject Component', () => {
                     Promise.resolve({
                         status: 'ok',
                         projects: [
-                            { project_id: 'proj_1', name: 'Alpha', owner: 'shaun', joined: false },
-                            { project_id: 'proj_2', name: 'Beta', owner: 'shaun', joined: true },
+                            { project_id: 'proj_1', name: 'Alpha', owner: 'alex' },
+                            { project_id: 'proj_2', name: 'Beta', owner: 'shaun' },
                         ],
                     }),
             })
@@ -95,7 +94,7 @@ describe('NewProject Component', () => {
                 json: () =>
                     Promise.resolve({
                         status: 'ok',
-                        projects: [{ project_id: 'proj_2', name: 'Beta', owner: 'shaun', joined: true }],
+                        projects: [{ project_id: 'proj_2', name: 'Beta', owner: 'shaun' }],
                     }),
             })
             .mockResolvedValueOnce({ json: () => Promise.resolve({ status: 'ok' }) })
@@ -125,8 +124,8 @@ describe('NewProject Component', () => {
                     Promise.resolve({
                         status: 'ok',
                         projects: [
-                            { project_id: 'proj_1', name: 'Alpha', owner: 'shaun', joined: false },
-                            { project_id: 'proj_2', name: 'Beta', owner: 'shaun', joined: true },
+                            { project_id: 'proj_1', name: 'Alpha', owner: 'alex' },
+                            { project_id: 'proj_2', name: 'Beta', owner: 'shaun' },
                         ],
                     }),
             })
@@ -209,7 +208,10 @@ describe('NewProject Component', () => {
                 json: () =>
                     Promise.resolve({
                         status: 'ok',
-                        projects: [{ project_id: 'proj_1', name: 'Alpha', owner: 'shaun', joined: false }],
+                        projects: [
+                            { project_id: 'proj_1', name: 'Alpha', owner: 'alex' },
+                            { project_id: 'proj_2', name: 'Beta', owner: 'shaun' },
+                        ],
                     }),
             })
             .mockRejectedValueOnce(new Error('leave failed'))
@@ -247,7 +249,7 @@ describe('NewProject Component', () => {
                 json: () =>
                     Promise.resolve({
                         status: 'ok',
-                        projects: [{ project_id: 'proj_1', name: 'Alpha', owner: 'shaun', joined: false }],
+                        projects: [{ project_id: 'proj_1', name: 'Alpha', owner: 'alex' }],
                     }),
             })
 


### PR DESCRIPTION
## Summary
Fix misleading frontend UI so the project page only shows actions that actually work, and make auth forms fail gracefully on request errors.

## Related Issue

Closes #

## Changes
Enabled leaving projects from the frontend for non-owner members
Removed the unused project description input from project creation
Hid the delete action unless the current user owns the project
Removed the unused/fake created-date display from the project list
Added simple error handling for login and account creation request failures
Updated frontend tests to match the new UI behavior
- 

## Validation

- [ ] Not applicable (docs/repo setup only)
- [ ] Local checks run

## Checklist

- [ ] Linked issue
- [ ] Scope matches issue
- [ ] No secrets committed
- [ ] Documentation updated if needed